### PR TITLE
Switch cache to a tree based storage structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ go-dns
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Ignore VS Code settings as these are not universally applicable right now
+.vscode

--- a/dns.go
+++ b/dns.go
@@ -66,7 +66,7 @@ func main() {
 					out = dnserr.Message(req.Header.ID, q).Encode()
 					break
 				}
-				cache.Store(resp)
+				cache.Cache(resp)
 				responses = append(responses, resp...)
 			}
 			if out == nil {

--- a/dns/cache/tree.go
+++ b/dns/cache/tree.go
@@ -1,0 +1,38 @@
+package cache
+
+import (
+	"errors"
+)
+
+// Node is a struct that is used to store a node (including it's contents) and a map[string] of pointers to it's children.
+type Node struct {
+	children map[string]*Node
+	Content  interface{}
+}
+
+// GetChild gets the pointer to a specific child of a node
+func (n Node) GetChild(name string) *Node {
+	c, ok := n.children[name]
+	if !ok {
+		return nil
+	}
+	return c
+}
+
+// AddChild adds a child to a node
+func (n *Node) AddChild(name string, c *Node) error {
+	if _, ok := n.children[name]; ok {
+		return errors.New("child does already exist")
+	}
+	n.children[name] = c
+	return nil
+}
+
+// RemoveChild removes the specified child from a node
+func (n *Node) RemoveChild(name string) error {
+	if _, ok := n.children[name]; !ok {
+		return errors.New("child does not exist")
+	}
+	delete(n.children, name)
+	return nil
+}

--- a/dns/cache/treeStorage.go
+++ b/dns/cache/treeStorage.go
@@ -1,0 +1,55 @@
+package cache
+
+import (
+	"github.com/fossoreslp/go-dns/dns/label"
+	"github.com/fossoreslp/go-dns/dns/record-names"
+	"github.com/fossoreslp/go-dns/dns/record-types"
+)
+
+// NewNode returns a new node containing store
+func NewNode(s *Store) *Node {
+	return &Node{make(map[string]*Node), s}
+}
+
+// RecordWrapper is used to add information like TTL and cache time to a DNS record
+type RecordWrapper struct {
+	Label    label.Label
+	Record   record.Record
+	TTL      uint32
+	StoredAt int64
+}
+
+// Store is a TreeStore used to store DNS records in a map by type
+type Store struct {
+	records map[names.TYPE][]RecordWrapper
+}
+
+// NewStore returns a new, initialized store
+func NewStore() *Store {
+	return &Store{make(map[names.TYPE][]RecordWrapper)}
+}
+
+// GetElement gets all records of a specific type stored by a node
+func (s Store) GetElement(t names.TYPE) []RecordWrapper {
+	if rs, ok := s.records[t]; ok {
+		return rs
+	}
+	return nil
+}
+
+// AddElement adds a slice of records of a specific type to a node
+func (s *Store) AddElement(t names.TYPE, rs []RecordWrapper) {
+	if _, ok := s.records[t]; !ok {
+		s.records[t] = rs
+		return
+	}
+	s.records[t] = append(s.records[t], rs...)
+}
+
+// RemoveElement deletes all records of a specific type from a node
+func (s *Store) RemoveElement(t names.TYPE) {
+	if _, ok := s.records[t]; !ok {
+		return //In case there are no records of the type, just ignore that
+	}
+	delete(s.records, t)
+}


### PR DESCRIPTION
I have switched the cache to use a tree-based system for storing records. The tree works using the separate parts of domains and therefore should increase performance a lot when storing large amounts of records. The first level is sorted by TLDs, while the second one is sorted by the domain name and then the subdomains for the consecutive levels. Therefore the number of records that need to be searched at each level decreases significantly and we should get to the correct record much faster.